### PR TITLE
incorrectly converted config to pytorch

### DIFF
--- a/train.py
+++ b/train.py
@@ -157,7 +157,7 @@ def setup_training_loop_kwargs(
         'paper256':  dict(ref_gpus=8,  kimg=25000,  mb=64, mbstd=8,  fmaps=0.5, lrate=0.0025, gamma=1,    ema=20,  ramp=None, map=8),
         'paper512':  dict(ref_gpus=8,  kimg=25000,  mb=64, mbstd=8,  fmaps=1,   lrate=0.0025, gamma=0.5,  ema=20,  ramp=None, map=8),
         'paper1024': dict(ref_gpus=8,  kimg=25000,  mb=32, mbstd=4,  fmaps=1,   lrate=0.002,  gamma=2,    ema=10,  ramp=None, map=8),
-        'cifar':     dict(ref_gpus=2,  kimg=100000, mb=64, mbstd=32, fmaps=1,   lrate=0.0025, gamma=0.01, ema=500, ramp=0.05, map=2),
+        'cifar':     dict(ref_gpus=2,  kimg=100000, mb=64, mbstd=32, fmaps=0.5,   lrate=0.0025, gamma=0.01, ema=500, ramp=0.05, map=2),
     }
 
     assert cfg in cfg_specs


### PR DESCRIPTION
Hello
I have experimented with your pytorch converted code, but the results didn't come out well.
So I checked and there was a difference from the original tensorflow code, so I modified it.

Could you please merge this PR ? (fmaps in tf: **0.5**, fmaps in pytorch: **1**)

pytorch: `'cifar':     dict(ref_gpus=2,  kimg=100000, mb=64, mbstd=32, fmaps=1,   lrate=0.0025, gamma=0.01, ema=500, ramp=0.05, map=2),`
tensorflow: `'cifar':     dict(ref_gpus=2,  kimg=100000, mb=64, mbstd=32, fmaps=0.5,   lrate=0.0025, gamma=0.01, ema=500, ramp=0.05, map=2),`
