### PR TITLE
Generate fake images for D in the torch.no_grad() context

### DIFF
--- a/training/loss.py
+++ b/training/loss.py
@@ -95,7 +95,8 @@ class StyleGAN2Loss(Loss):
         loss_Dgen = 0
         if do_Dmain:
             with torch.autograd.profiler.record_function('Dgen_forward'):
-                gen_img, _gen_ws = self.run_G(gen_z, gen_c, sync=False)
+                with torch.no_grad():
+                    gen_img, _gen_ws = self.run_G(gen_z, gen_c, sync=False)
                 gen_logits = self.run_D(gen_img, gen_c, sync=False) # Gets synced by loss_Dreal.
                 training_stats.report('Loss/scores/fake', gen_logits)
                 training_stats.report('Loss/signs/fake', gen_logits.sign())


### PR DESCRIPTION
There is no need to perform the generator's forward pass in the grad-enabled mode when generating images for the discriminator. Disabling the gradient improved training speed for me on 4 v100s for a 256x256 dataset from 5 kimg/s to 4 kimg/s.

Before:
```

```

After:
```
tick 1     kimg 4.1      time 1m 23s       sec/tick 24.4    sec/kimg 6.04    maintenance 12.9   cpumem 3.48   gpumem 5.04   augment 0.004
tick 2     kimg 8.1      time 1m 48s       sec/tick 24.9    sec/kimg 6.18    maintenance 0.0    cpumem 3.48   gpumem 5.04   augment 0.012
tick 3     kimg 12.2     time 2m 13s       sec/tick 25.1    sec/kimg 6.23    maintenance 0.0    cpumem 3.48   gpumem 5.04   augment 0.020
tick 4     kimg 16.2     time 2m 38s       sec/tick 24.9    sec/kimg 6.18    maintenance 0.0    cpumem 3.49   gpumem 5.04   augment 0.019
tick 5     kimg 20.2     time 3m 03s       sec/tick 24.8    sec/kimg 6.15    maintenance 0.1    cpumem 3.49   gpumem 5.04   augment 0.020
tick 6     kimg 24.3     time 3m 28s       sec/tick 25.1    sec/kimg 6.23    maintenance 0.1    cpumem 3.49   gpumem 5.04   augment 0.025
tick 7     kimg 28.3     time 3m 53s       sec/tick 25.0    sec/kimg 6.20    maintenance 0.0    cpumem 3.49   gpumem 5.04   augment 0.028
tick 8     kimg 32.3     time 4m 18s       sec/tick 25.2    sec/kimg 6.25    maintenance 0.1    cpumem 3.50   gpumem 5.04   augment 0.031
tick 9     kimg 36.4     time 4m 44s       sec/tick 25.9    sec/kimg 6.43    maintenance 0.1    cpumem 3.50   gpumem 5.04   augment 0.038
tick 10    kimg 40.4     time 5m 10s       sec/tick 25.5    sec/kimg 6.33    maintenance 0.0    cpumem 3.50   gpumem 5.04   augment 0.041
```